### PR TITLE
Localization(frontend): fix aria labels, number formatting, and DataGrid texts per audit; add missing en/uk keys (batched)

### DIFF
--- a/src/components/grid/ThemedDataGrid.tsx
+++ b/src/components/grid/ThemedDataGrid.tsx
@@ -1,10 +1,20 @@
 import { DataGrid, DataGridProps } from "@mui/x-data-grid"
 import React from "react"
+import { useTranslation } from "react-i18next"
 
 export function ThemedDataGrid(props: DataGridProps) {
+  const { t } = useTranslation()
   return (
     <DataGrid
       {...props}
+      localeText={{
+        noRowsLabel: t("ui.datagrid.noRows"),
+        noResultsOverlayLabel: t("ui.datagrid.noResults"),
+        footerPaginationRowsPerPage: t("ui.datagrid.rowsPerPage"),
+        footerPaginationLabelDisplayedRows: ({ from, to, count }) =>
+          t("ui.datagrid.displayedRows", { from, to, count }),
+        ...props.localeText,
+      }}
       sx={{
         borderColor: "outline.main",
         [`& .MuiDataGrid-cell, & .MuiDataGrid-filler > *, & .MuiDataGrid-footerContainer, & .MuiDataGrid-columnSeparator, & .MuiDataGrid-toolbar`]:

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -412,7 +412,7 @@ export function Sidebar() {
               >
                 <Avatar
                   src={avatar}
-                  aria-label="current contractor"
+                  aria-label={t("ui.aria.currentContractor")}
                   variant={"rounded"}
                   sx={{
                     maxHeight: theme.spacing(6),

--- a/src/locales/en/english.json
+++ b/src/locales/en/english.json
@@ -22,7 +22,10 @@
     "submit": "Submit",
     "loginWithDiscord": "Login with Discord",
     "accountLink": "Account Link",
-    "authenticateWithRSI": "Authenticate with RSI"
+    "authenticateWithRSI": "Authenticate with RSI",
+    "aria": {
+      "outlinedGroup": "outlined button group"
+    }
   },
   "availability": {
     "select_availability": "Select Availability",
@@ -101,6 +104,9 @@
     "item_name": "Item Name",
     "other_category": "Other",
     "allListings": "All Market Listings",
+    "aria": {
+      "listingTabs": "market listing tabs"
+    },
     "toggleSidebar": "toggle market sidebar",
     "activeListings": "Active Listings",
     "inactiveListings": "Inactive Listings",
@@ -610,7 +616,10 @@
     "orderShort": "Order {{id}}",
     "offerShort": "Offer {{id}}",
     "createOrderTitle": "Create Order",
-    "viewOrder": "View Order"
+    "viewOrder": "View Order",
+    "aria": {
+      "orderTabs": "order tabs"
+    }
   },
   "orderDetailsArea": {
     "updated_status": "Updated status!",
@@ -1399,7 +1408,10 @@
     "dashboard": "Dashboard",
     "offer": "Offer",
     "receivedOffers": "Received Offers",
-    "counterOffer": "Counter Offer"
+    "counterOffer": "Counter Offer",
+    "aria": {
+      "offerTabs": "offer tabs"
+    }
   },
   "sendMoney": {
     "title": "Send Money",
@@ -1521,6 +1533,9 @@
   "dashboard": {
     "title": "Dashboard"
   },
+  "contractors": {
+    "contractor": "contractor"
+  },
   "contractorsPage": {
     "title": "Contractors"
   },
@@ -1539,5 +1554,19 @@
     "title": "Login",
     "accountLink": "Account Link",
     "authenticateWithRSI": "Authenticate with RSI"
+  },
+  "ui": {
+    "aria": {
+      "orgInfoArea": "org info area",
+      "breadcrumb": "breadcrumb",
+      "loadingButtonGroup": "contained primary loadingButton group",
+      "currentContractor": "current contractor"
+    },
+    "datagrid": {
+      "noRows": "No rows",
+      "noResults": "No results",
+      "rowsPerPage": "Rows per page:",
+      "displayedRows": "{{from}}-{{to}} of {{count}}"
+    }
   }
 }

--- a/src/locales/uk/ukrainian.json
+++ b/src/locales/uk/ukrainian.json
@@ -22,7 +22,10 @@
     "submit": "Надіслати",
     "loginWithDiscord": "Увійти через Discord",
     "accountLink": "Прив’язка акаунта",
-    "authenticateWithRSI": "Аутентифікація через RSI"
+    "authenticateWithRSI": "Аутентифікація через RSI",
+    "aria": {
+      "outlinedGroup": "група кнопок з обводкою"
+    }
   },
   "availability": {
     "select_availability": "Оберіть доступність",
@@ -101,6 +104,9 @@
     "item_name": "Назва предмета",
     "other_category": "Інше",
     "allListings": "Всі оголошення на маркеті",
+    "aria": {
+      "listingTabs": "вкладки оголошень ринку"
+    },
     "toggleSidebar": "Перемкнути бокове меню маркету",
     "activeListings": "Активні оголошення",
     "inactiveListings": "Неактивні оголошення",
@@ -610,7 +616,10 @@
     "orderShort": "Замовлення {{id}}",
     "offerShort": "Пропозиція {{id}}",
     "createOrderTitle": "Створити замовлення",
-    "viewOrder": "Перегляд замовлення"
+    "viewOrder": "Перегляд замовлення",
+    "aria": {
+      "orderTabs": "вкладки замовлень"
+    }
   },
   "orderDetailsArea": {
     "updated_status": "Статус оновлено!",
@@ -1399,7 +1408,10 @@
     "dashboard": "Панель",
     "offer": "Пропозиція",
     "receivedOffers": "Отримані пропозиції",
-    "counterOffer": "Зустрічна пропозиція"
+    "counterOffer": "Зустрічна пропозиція",
+    "aria": {
+      "offerTabs": "вкладки пропозицій"
+    }
   },
   "sendMoney": {
     "title": "Надіслати кошти",
@@ -1521,6 +1533,9 @@
   "dashboard": {
     "title": "Панель управління"
   },
+  "contractors": {
+    "contractor": "підрядник"
+  },
   "contractorsPage": {
     "title": "Підрядники"
   },
@@ -1539,5 +1554,19 @@
     "title": "Вхід",
     "accountLink": "Прив'язка акаунта",
     "authenticateWithRSI": "Авторизація через RSI"
+  },
+  "ui": {
+    "aria": {
+      "orgInfoArea": "область інформації про організацію",
+      "breadcrumb": "навігаційний ланцюжок",
+      "loadingButtonGroup": "група кнопок завантаження",
+      "currentContractor": "поточний підрядник"
+    },
+    "datagrid": {
+      "noRows": "Немає рядків",
+      "noResults": "Немає результатів",
+      "rowsPerPage": "Рядків на сторінку:",
+      "displayedRows": "{{from}}–{{to}} з {{count}}"
+    }
   }
 }

--- a/src/pages/contractor/OrgManage.tsx
+++ b/src/pages/contractor/OrgManage.tsx
@@ -69,7 +69,7 @@ export function OrgManage() {
             <Tabs
               value={page}
               onChange={handleChange}
-              aria-label="org info area"
+              aria-label={t("ui.aria.orgInfoArea")}
               variant="scrollable"
             >
               {canManageOrgDetails && (

--- a/src/pages/contractor/OrgRegister.tsx
+++ b/src/pages/contractor/OrgRegister.tsx
@@ -27,7 +27,7 @@ export function OrgRegister() {
           <Tabs
             value={page}
             onChange={(_, newPage) => setPage(newPage)}
-            aria-label="org info area"
+            aria-label={t("ui.aria.orgInfoArea")}
             variant="scrollable"
           >
             <Tab

--- a/src/pages/market/MarketCreate.tsx
+++ b/src/pages/market/MarketCreate.tsx
@@ -37,7 +37,7 @@ export function MarketCreate(props: {}) {
           <Tabs
             value={page}
             // onChange={handleChange}
-            aria-label="market listing tabs"
+            aria-label={t("market.aria.listingTabs")}
             variant="scrollable"
             textColor="secondary"
             indicatorColor="secondary"

--- a/src/pages/market/MarketPage.tsx
+++ b/src/pages/market/MarketPage.tsx
@@ -74,7 +74,7 @@ export function MarketPage() {
                 </Typography>
                 <Tabs
                   value={tabPage}
-                  aria-label="org info area"
+                  aria-label={t("ui.aria.orgInfoArea")}
                   variant="scrollable"
                   textColor="secondary"
                   indicatorColor="secondary"

--- a/src/pages/people/SettingsPage.tsx
+++ b/src/pages/people/SettingsPage.tsx
@@ -40,7 +40,7 @@ export function SettingsPage() {
           <Tabs
             value={page}
             onChange={handleChange}
-            aria-label="org info area"
+            aria-label={t("ui.aria.orgInfoArea")}
             variant="scrollable"
             textColor="secondary"
             indicatorColor="secondary"

--- a/src/views/authentication/Authenticate.tsx
+++ b/src/views/authentication/Authenticate.tsx
@@ -49,7 +49,7 @@ export function Authenticate(props: {}) {
       </Grid>
       <Grid item xs={12} alignItems={"center"} container>
         <Typography display={"inline"}>{t("auth.loginWith")}</Typography>
-        <ButtonGroup variant="outlined" aria-label="outlined button group">
+        <ButtonGroup variant="outlined" aria-label={t("auth.aria.outlinedGroup")}>
           <IconButton color={"primary"}>
             <Google />
           </IconButton>

--- a/src/views/contractor/ContractorList.tsx
+++ b/src/views/contractor/ContractorList.tsx
@@ -119,7 +119,7 @@ export function ContractorListItem(props: {
                         contractor.avatar ||
                         "https://cdn.robertsspaceindustries.com/static/images/Temp/default-image.png"
                       }
-                      aria-label="contractor"
+                      aria-label={t("contractors.contractor")}
                       variant={"rounded"}
                       imgProps={{
                         onError: ({ currentTarget }) => {

--- a/src/views/contractor/OrgBalance.tsx
+++ b/src/views/contractor/OrgBalance.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 
 export function OrgBalance() {
   const [contractor] = useCurrentOrg()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   return (
     <Section>
@@ -33,7 +33,7 @@ export function OrgBalance() {
         >
           {contractor &&
             contractor?.balance &&
-            contractor?.balance.toLocaleString("en-US")}{" "}
+            contractor?.balance.toLocaleString(i18n.language)}{" "}
           aUEC
         </Typography>
       </Grid>

--- a/src/views/contractor/OrgInfo.tsx
+++ b/src/views/contractor/OrgInfo.tsx
@@ -171,7 +171,7 @@ export function OrgInfo(props: { contractor: Contractor }) {
                     <Grid item sm={4}>
                       <Avatar
                         src={contractor?.avatar}
-                        aria-label="contractor"
+                        aria-label={t("contractors.contractor")}
                         variant={"rounded"}
                         sx={{
                           maxHeight: theme.spacing(12),
@@ -272,7 +272,7 @@ export function OrgInfo(props: { contractor: Contractor }) {
                 <Tabs
                   value={page}
                   // onChange={handleChange}
-                  aria-label="org info area"
+                  aria-label={t("ui.aria.orgInfoArea")}
                   variant="scrollable"
                 >
                   <Tab
@@ -386,7 +386,7 @@ export function OrgInfoSkeleton() {
           <Tabs
             value={page}
             onChange={handleChange}
-            aria-label="org info area"
+            aria-label={t("ui.aria.orgInfoArea")}
             variant="scrollable"
           >
             <Tab

--- a/src/views/contractor/OrgManage.tsx
+++ b/src/views/contractor/OrgManage.tsx
@@ -156,7 +156,7 @@ export function OrgDetailEditForm(props: { contractor: Contractor }) {
                 </IconButton>
                 <Avatar
                   src={contractor?.avatar}
-                  aria-label="contractor"
+                  aria-label={t("contractors.contractor")}
                   variant={"rounded"}
                   sx={{
                     maxHeight: theme.spacing(12),

--- a/src/views/market/Bids.tsx
+++ b/src/views/market/Bids.tsx
@@ -12,6 +12,7 @@ import { UnderlineLink } from "../../components/typography/UnderlineLink"
 import { getRelativeTime } from "../../util/time"
 import { useMarketAcceptBidMutation } from "../../store/market"
 import { useAlertHook } from "../../hooks/alert/AlertHook"
+import { useTranslation } from "react-i18next"
 
 export interface BidRowProps {
   row: MarketBid
@@ -23,6 +24,7 @@ export interface BidRowProps {
 
 export function BidRow(props: BidRowProps): JSX.Element {
   const { row, index, isItemSelected } = props // TODO: Add `assigned_to` column
+  const { i18n } = useTranslation()
 
   return (
     <TableRow
@@ -57,7 +59,7 @@ export function BidRow(props: BidRowProps): JSX.Element {
       </TableCell>
       <TableCell align="right">
         <Typography variant={"subtitle1"} color={"text.primary"}>
-          {row.bid.toLocaleString("en-US")} aUEC
+          {row.bid.toLocaleString(i18n.language)} aUEC
         </Typography>
       </TableCell>
 

--- a/src/views/market/ItemListings.tsx
+++ b/src/views/market/ItemListings.tsx
@@ -154,7 +154,7 @@ export function ItemListingBase(props: {
   listing: UniqueListing
   index: number
 }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { listing: complete, index } = props
   const { details, listing, auction_details, photos } = complete
   const { user_seller, contractor_seller } = listing
@@ -292,7 +292,7 @@ export function ItemListingBase(props: {
               }}
             >
               <Typography variant={"h5"} color={"primary"} fontWeight={"bold"}>
-                {listing.price.toLocaleString("en-US")} aUEC
+                {listing.price.toLocaleString(i18n.language)} aUEC
               </Typography>
               <Typography
                 variant={"subtitle2"}

--- a/src/views/market/ItemMarketView.tsx
+++ b/src/views/market/ItemMarketView.tsx
@@ -17,18 +17,20 @@ import { useTheme } from "@mui/material/styles"
 import { useDrawerOpen } from "../../hooks/layout/Drawer"
 import CloseIcon from "@mui/icons-material/CloseRounded"
 import MenuIcon from "@mui/icons-material/MenuRounded"
+import { useTranslation } from "react-i18next"
 
 export function ItemMarketView() {
   const theme = useTheme()
   const xs = useMediaQuery(theme.breakpoints.down("md"))
   const drawerOpen = useDrawerOpen()
   const [open, setOpen] = useState(false)
+  const { t } = useTranslation()
 
   return (
     <>
       <IconButton
         color="secondary"
-        aria-label="toggle market sidebar"
+        aria-label={t("market.toggleSidebar")}
         sx={{
           position: "absolute",
           zIndex: 50,

--- a/src/views/market/MarketAggregateView.tsx
+++ b/src/views/market/MarketAggregateView.tsx
@@ -281,7 +281,7 @@ export function MarketAggregateView() {
                   spacing={1}
                   justifyContent={"left"}
                 >
-                  <Breadcrumbs aria-label="breadcrumb" color={"text.primary"}>
+                  <Breadcrumbs aria-label={t("ui.aria.breadcrumb")} color={"text.primary"}>
                     <MaterialLink
                       component={Link}
                       underline="hover"
@@ -431,7 +431,7 @@ export function AggregateRow(props: {
   isItemSelected: boolean
   labelId: string
 }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { row: listing, index } = props
   const [quantity, setQuantity] = useState(1)
   const issueAlert = useAlertHook()
@@ -532,7 +532,7 @@ export function AggregateRow(props: {
         }}
       >
         <Typography variant={"subtitle2"} color={"primary"}>
-          {listing.price.toLocaleString("en-US")} aUEC
+          {listing.price.toLocaleString(i18n.language)} aUEC
         </Typography>
       </TableCell>
 
@@ -597,7 +597,7 @@ export function BuyOrderRow(props: {
   isItemSelected: boolean
   labelId: string
 }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { row: buy_order, index } = props
   const issueAlert = useAlertHook()
 
@@ -691,7 +691,7 @@ export function BuyOrderRow(props: {
         }}
       >
         <Typography variant={"subtitle2"} color={"primary"}>
-          {buy_order.price.toLocaleString("en-US")} aUEC
+          {buy_order.price.toLocaleString(i18n.language)} aUEC
         </Typography>
       </TableCell>
 
@@ -702,7 +702,7 @@ export function BuyOrderRow(props: {
         }}
       >
         <Typography variant={"subtitle2"} color={"primary"}>
-          {buy_order.quantity.toLocaleString("en-US")}
+          {buy_order.quantity.toLocaleString(i18n.language)}
         </Typography>
       </TableCell>
 
@@ -713,7 +713,7 @@ export function BuyOrderRow(props: {
         }}
       >
         <Typography variant={"subtitle2"} color={"primary"}>
-          {buy_order.total.toLocaleString("en-US")} aUEC
+          {buy_order.total.toLocaleString(i18n.language)} aUEC
         </Typography>
       </TableCell>
 

--- a/src/views/market/MarketListingView.tsx
+++ b/src/views/market/MarketListingView.tsx
@@ -556,7 +556,7 @@ export function MarketListingView() {
                           justifyContent={"left"}
                         >
                           <Breadcrumbs
-                            aria-label="breadcrumb"
+                            aria-label={t("ui.aria.breadcrumb")}
                             color={"text.primary"}
                           >
                             <MaterialLink

--- a/src/views/market/MarketMultipleView.tsx
+++ b/src/views/market/MarketMultipleView.tsx
@@ -232,7 +232,7 @@ export function MarketMultipleView() {
                           justifyContent={"left"}
                         >
                           <Breadcrumbs
-                            aria-label="breadcrumb"
+                            aria-label={t("ui.aria.breadcrumb")}
                             color={"text.primary"}
                           >
                             <MaterialLink

--- a/src/views/market/MarketSidebar.tsx
+++ b/src/views/market/MarketSidebar.tsx
@@ -392,11 +392,12 @@ export function MarketSideBarToggleButton() {
   const [open, setOpen] = useMarketSidebar()
   const theme = useTheme<ExtendedTheme>()
   const [drawerOpen] = useDrawerOpen()
+  const { t } = useTranslation()
 
   return (
     <IconButton
       color="secondary"
-      aria-label="toggle market sidebar"
+      aria-label={t("market.toggleSidebar")}
       sx={{
         zIndex: theme.zIndex.drawer - 2,
         position: "absolute",

--- a/src/views/market/SellMaterialsList.tsx
+++ b/src/views/market/SellMaterialsList.tsx
@@ -70,7 +70,7 @@ function SellItemRow(props: {
   isItemSelected: boolean
   labelId: string
 }): JSX.Element {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const { row, onClick, isItemSelected, labelId } = props
   const bgColor = useMemo(
     () => (kindIcons[row.kind] ? kindIcons[row.kind][1] : "#FFF"),
@@ -112,7 +112,7 @@ function SellItemRow(props: {
 
       <TableCell align="right">
         <Typography variant={"subtitle1"} color={"secondary"}>
-          {(row.trade_price_sell * 0.9).toLocaleString("en-US")} aUEC
+          {(row.trade_price_sell * 0.9).toLocaleString(i18n.language)} aUEC
         </Typography>
       </TableCell>
 

--- a/src/views/member/MemberBalance.tsx
+++ b/src/views/member/MemberBalance.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 
 export function MemberBalance() {
   const profile = useGetUserProfileQuery()
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   return (
     <Section xs={12} lg={12}>
@@ -32,7 +32,7 @@ export function MemberBalance() {
           sx={{ fontWeight: "bold", transition: "0.3s" }}
         >
           {profile.data?.balance &&
-            profile.data?.balance.toLocaleString("en-US")}{" "}
+            profile.data?.balance.toLocaleString(i18n.language)}{" "}
           aUEC
         </Typography>
       </Grid>

--- a/src/views/offers/OfferDetailsArea.tsx
+++ b/src/views/offers/OfferDetailsArea.tsx
@@ -184,7 +184,7 @@ export function OfferDetailsArea(props: { session: OfferSession }) {
   return (
     <Grid item xs={12} lg={8} md={6}>
       <TableContainer component={Paper}>
-        <Table aria-label="details table">
+        <Table aria-label={t("offers.details_table")}>
           <TableBody>
             <TableRow
               sx={{

--- a/src/views/offers/OfferDetailsEditArea.tsx
+++ b/src/views/offers/OfferDetailsEditArea.tsx
@@ -32,7 +32,7 @@ export function OfferDetailsEditArea(props: { session: OfferSession }) {
   return (
     <Grid item xs={12} lg={12} md={12}>
       <TableContainer component={Paper}>
-        <Table aria-label="details table" sx={{ overflowY: "hidden" }}>
+        <Table aria-label={t("offers.details_table")} sx={{ overflowY: "hidden" }}>
           <TableBody>
             <TableRow
               sx={{

--- a/src/views/offers/ReceivedOffersArea.tsx
+++ b/src/views/offers/ReceivedOffersArea.tsx
@@ -259,7 +259,7 @@ export function OffersViewPaginated(props: {
           <Tabs
             value={tab}
             // onChange={(_, newPage) => setPage(newPage)}
-            aria-label="offer tabs"
+            aria-label={t("offers.aria.offerTabs")}
             variant="scrollable"
           >
             <Tab

--- a/src/views/orders/OrderDetailsArea.tsx
+++ b/src/views/orders/OrderDetailsArea.tsx
@@ -409,7 +409,7 @@ export function OrderDetailsArea(props: { order: Order }) {
                     amAssigned) && (
                     <ButtonGroup
                       variant="contained"
-                      aria-label="contained primary loadingButton group"
+                      aria-label={t("ui.aria.loadingButtonGroup")}
                     >
                       {(profile?.role === "admin" ||
                         order.status === "not-started" ||

--- a/src/views/orders/OrderList.tsx
+++ b/src/views/orders/OrderList.tsx
@@ -351,7 +351,7 @@ export function OrdersViewPaginated(props: {
           <Tabs
             value={tab}
             // onChange={(_, newPage) => setPage(newPage)}
-            aria-label="order tabs"
+            aria-label={t("orders.aria.orderTabs")}
             variant="scrollable"
           >
             {tabs.map(([id, tag], index) => (

--- a/src/views/orders/OrderMetrics.tsx
+++ b/src/views/orders/OrderMetrics.tsx
@@ -50,7 +50,7 @@ export function OrderMetrics(props: {}) {
     skip: !!contractor,
   })
 
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const filteredOrders = useCallback(
     (state?: string) => {
@@ -82,7 +82,7 @@ export function OrderMetrics(props: {}) {
         </Grid>
         <Grid item xs={12}>
           <Typography variant={"h6"} color={"success.main"}>
-            {filteredOrders("active").length.toLocaleString("en-US")}
+            {filteredOrders("active").length.toLocaleString(i18n.language)}
           </Typography>
         </Grid>
         <Grid item xs={12}>

--- a/src/views/orders/Services.tsx
+++ b/src/views/orders/Services.tsx
@@ -62,7 +62,7 @@ export const BorderlessCell = styled(TableCell)({
 export function ServiceDetailsRow(props: { open: boolean; service: Service }) {
   const theme = useTheme<ExtendedTheme>()
   const { open, service } = props
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   return (
     <TableRow
@@ -193,7 +193,7 @@ export function MobileServiceRow(props: ServiceRowProps) {
             </span>
           </Box>
           <Typography variant={"subtitle2"} color={"primary"}>
-            {row.cost.toLocaleString("en-US")} aUEC {paymentType}
+            {row.cost.toLocaleString(i18n.language)} aUEC {paymentType}
           </Typography>
         </BorderlessCell>
 

--- a/src/views/people/ViewProfile.tsx
+++ b/src/views/people/ViewProfile.tsx
@@ -236,9 +236,9 @@ function BannerEditArea(props: {
       </Collapse>
 
       {isMyProfile && (
-        <Fab
+          <Fab
           color={bannerEntryOpen ? "primary" : "secondary"}
-          aria-label="Set new banner"
+          aria-label={t("orgDetailEdit.set_banner")}
           onClick={async () => {
             if (bannerEntryOpen && newBannerURL) {
               await submitUpdate({ banner_url: newBannerURL })
@@ -630,7 +630,7 @@ export function ViewProfile(props: { profile: User }) {
               <Tabs
                 value={page}
                 // onChange={handleChange}
-                aria-label="org info area"
+                aria-label={t("ui.aria.orgInfoArea")}
                 variant="scrollable"
                 textColor="secondary"
                 indicatorColor="secondary"

--- a/src/views/transactions/TransactionTableView.tsx
+++ b/src/views/transactions/TransactionTableView.tsx
@@ -74,7 +74,7 @@ export function TransactionTableRow(props: {
   labelId: string
 }) {
   const { row, index, isItemSelected } = props
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const { data: profile } = useGetUserProfileQuery()
   const userRec = useMemo(
@@ -136,12 +136,12 @@ export function TransactionTableRow(props: {
           {row.status === "Cancelled" ? (
             <Typography sx={{ textDecoration: "line-through" }}>
               {receiving ? "" : "-"}
-              {row.amount.toLocaleString("en-US")} aUEC
+              {row.amount.toLocaleString(i18n.language)} aUEC
             </Typography>
           ) : (
             <Typography color={receiving ? "success.light" : "error.dark"}>
               {receiving ? "" : "-"}
-              {row.amount.toLocaleString("en-US")} aUEC
+              {row.amount.toLocaleString(i18n.language)} aUEC
             </Typography>
           )}
         </TableCell>


### PR DESCRIPTION
## Summary
- replace hard-coded aria-labels with i18n keys
- use `i18n.language` for number formatting
- localize MUI DataGrid texts and add English/Ukrainian keys